### PR TITLE
Fix routing: standardize links and update services anchor behavior

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -2,6 +2,7 @@
 
 import styles from './Footer.module.css';
 import { FaEnvelope } from 'react-icons/fa';
+import { useRouter } from 'next/router';
 
 export default function Footer() {
   const triggerVibration = () => {
@@ -9,6 +10,8 @@ export default function Footer() {
       navigator.vibrate([20]); // simple haptic tap
     }
   };
+
+  const router = useRouter();
 
   return (
     <footer className={styles.footer}>
@@ -25,10 +28,30 @@ export default function Footer() {
 
         <div className={styles.footerColumn}>
           <h3>LINKS</h3>
-          <p><a href="#home" onClick={triggerVibration}> Home</a></p>
-          <p><a href="#service" onClick={triggerVibration}> Service</a></p>
-          <p><a href="#blogs" onClick={triggerVibration}> Blogs</a></p>
-          <p><a href="#about" onClick={triggerVibration}> About Us</a></p>
+          <p>
+            <a href="/" onClick={triggerVibration}>
+              {" "}
+              Home
+            </a>
+          </p>
+          <p>
+            <a href={router.pathname === "/" ? "/#services" : "/services"} onClick={triggerVibration}>
+              {" "}
+              Services
+            </a>
+          </p>
+          <p>
+            <a href="/blog" onClick={triggerVibration}>
+              {" "}
+              Blogs
+            </a>
+          </p>
+          <p>
+            <a href="/about" onClick={triggerVibration}>
+              {" "}
+              About Us
+            </a>
+          </p>
         </div>
 
         <div className={styles.footerColumn}>

--- a/components/HeroSection.jsx
+++ b/components/HeroSection.jsx
@@ -75,15 +75,40 @@ export default function HeroSection() {
 
           {/* Navigation Links with hover underline */}
           <nav className="hidden md:flex space-x-6 text-sm">
-            <Link href="#" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">Home</Link>
-            <Link href="#services" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">Services</Link>
-            <Link href="#blogs" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">Blogs</Link>
-            <Link href="/about" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">About Us</Link>
-            <Link href="/careers" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">Careers</Link>
+            <Link
+              href="/"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Home
+            </Link>
+            <Link
+              href={router.pathname === "/" ? "/#services" : "/services"}
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Services
+            </Link>
+            <Link
+              href="/blog"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Blogs
+            </Link>
+            <Link
+              href="/about"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              About Us
+            </Link>
+            <Link
+              href="/careers"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Careers
+            </Link>
           </nav>
 
           {/* CTA Button */}
-          <Link href="#contact">
+          <Link href="/#contact">
             <button
               className="bg-[#ccd6f6] text-black font-semibold py-2 px-4 rounded-xl shadow hover:bg-white transition flex items-center gap-2"
               onClick={vibrateAndroid}
@@ -159,23 +184,43 @@ export default function HeroSection() {
 
       {/* Bottom Navigation Panel - Mobile only */}
       <nav className="fixed bottom-0 left-0 right-0 bg-black/80 backdrop-blur-md border-t border-white/20 text-white flex justify-around items-center py-3 md:hidden z-50">
-        <Link href="#" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span></span>
           <span>Home</span>
         </Link>
-        <Link href="#services" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href={router.pathname === "/" ? "/#services" : "/services"}
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span></span>
           <span>Services</span>
         </Link>
-        <Link href="#blogs" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/blog"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span></span>
           <span>Blogs</span>
         </Link>
-        <Link href="#contact" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/#contact"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span></span>
           <span>Contact</span>
         </Link>
-        <Link href="/careers" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/careers"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span></span>
           <span>Careers</span>
         </Link>

--- a/components/ServicesSection.jsx
+++ b/components/ServicesSection.jsx
@@ -88,8 +88,11 @@ export default function ServicesSection() {
               transition={{ type: 'spring', stiffness: 300, damping: 15 }}
               className="mt-6 bg-[#ccd6f6] text-black font-semibold py-2 px-4 rounded-lg hover:bg-white transition"
               onClick={() => {
-                if (typeof window !== 'undefined' && 'vibrate' in navigator) {
-                  navigator.vibrate(10); // Haptic feedback for mobile
+                if (typeof window !== "undefined" && "vibrate" in navigator) {
+                  navigator.vibrate(10);
+                }
+                if (typeof window !== "undefined") {
+                  window.location.assign("/services");
                 }
               }}
             >

--- a/components/UnderDevelopment.jsx
+++ b/components/UnderDevelopment.jsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { useRouter } from "next/router";
+
+export default function UnderDevelopment({
+  title = "Under Development",
+  description = "This page is being prepared. Please check back soon.",
+}) {
+  const router = useRouter();
+  const servicesHref = router.pathname === "/" ? "/#services" : "/services";
+  return (
+    <>
+      <header className="fixed top-6 left-1/2 -translate-x-1/2 z-50 w-[95%] max-w-6xl px-6 py-3 rounded-3xl bg-[rgba(255,255,255,0.05)] backdrop-blur-xl border border-white/20 shadow-md">
+        <div className="flex justify-between items-center">
+          <div className="flex items-center space-x-3">
+            <Image
+              src="/logonavbar.png"
+              alt="Arctic44 Logo"
+              width={100}
+              height={40}
+            />
+          </div>
+          <nav className="hidden md:flex space-x-6 text-sm">
+            <Link
+              href="/"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Home
+            </Link>
+            <Link
+              href={servicesHref}
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Services
+            </Link>
+            <Link
+              href="/blog"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Blogs
+            </Link>
+            <Link
+              href="/about"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              About Us
+            </Link>
+            <Link
+              href="/careers"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Careers
+            </Link>
+          </nav>
+          <Link href="/#contact">
+            <button className="bg-[#ccd6f6] text-black font-semibold py-2 px-4 rounded-xl shadow hover:bg-white transition">
+              Get in Touch
+            </button>
+          </Link>
+        </div>
+      </header>
+      <main className="min-h-screen bg-black text-white flex items-center justify-center p-6 pt-40">
+        <div className="text-center space-y-6">
+          <h1 className="text-4xl font-bold text-[#66ccff]">{title}</h1>
+          <p className="text-gray-300">{description}</p>
+          <div className="flex gap-4 justify-center">
+            <Link className="text-[#66ccff] underline" href="/">
+              Go Home
+            </Link>
+            <Link className="text-[#66ccff] underline" href="/about">
+              About
+            </Link>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/pages/about.js
+++ b/pages/about.js
@@ -128,11 +128,34 @@ export default function About() {
           </div>
 
           <nav className="hidden md:flex space-x-6 text-sm">
-            <Link href="/" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">Home</Link>
-            <Link href="/services" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">Services</Link>
-            <Link href="/blogs" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">Blogs</Link>
-            <Link href="/about" className="text-white border-b-2 border-white">About Us</Link>
-            <Link href="/careers" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">Careers</Link>
+            <Link
+              href="/"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Home
+            </Link>
+            <Link
+              href="/services"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Services
+            </Link>
+            <Link
+              href="/blog"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Blogs
+            </Link>
+            <Link href="/about" className="text-white border-b-2 border-white">
+              About Us
+            </Link>
+            
+            <Link
+              href="/careers"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Careers
+            </Link>
           </nav>
 
           <Link href="/#contact">
@@ -442,19 +465,39 @@ export default function About() {
 
       {/* Bottom Mobile Navigation */}
       <nav className="fixed bottom-0 left-0 right-0 bg-black/80 backdrop-blur-md border-t border-white/20 text-white flex justify-around items-center py-3 md:hidden z-50">
-        <Link href="/" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span>Home</span>
         </Link>
-        <Link href="/services" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/services"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span>Services</span>
         </Link>
-        <Link href="/blogs" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/blog"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span>Blogs</span>
         </Link>
-        <Link href="/contact" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/contact"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span>Contact</span>
         </Link>
-        <Link href="/careers" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/careers"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span>Careers</span>
         </Link>
       </nav>

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -1,0 +1,23 @@
+"use client";
+
+import Head from "next/head";
+import UnderDevelopment from "@/components/UnderDevelopment";
+
+export default function Blog() {
+  return (
+    <>
+      <Head>
+        <title>Blog – Arctic44</title>
+        <meta
+          name="description"
+          content="Our blog is currently under development."
+        />
+      </Head>
+
+      <UnderDevelopment
+        title="blogs"
+        description="This page is currently under development."
+      />
+    </>
+  );
+}

--- a/pages/careers.js
+++ b/pages/careers.js
@@ -110,7 +110,7 @@ export default function Careers() {
               Careers
             </Link>
           </nav>
-          <Link href="/contact">
+          <Link href="/#contact">
             <button
               className="bg-[#ccd6f6] text-black font-semibold py-2 px-4 rounded-xl shadow hover:bg-white transition flex items-center gap-2"
               onClick={vibrateAndroid}

--- a/pages/careers.js
+++ b/pages/careers.js
@@ -79,11 +79,36 @@ export default function Careers() {
             <Image src="/logonavbar.png" alt="Arctic44 Logo" width={100} height={40} />
           </div>
           <nav className="hidden md:flex space-x-6 text-sm">
-            <Link href="/" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">Home</Link>
-            <Link href="/services" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">Services</Link>
-            <Link href="/blogs" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">Blogs</Link>
-            <Link href="/about" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">About Us</Link>
-            <Link href="/careers" className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition">Careers</Link>
+            <Link
+              href="/"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Home
+            </Link>
+            <Link
+              href="/services"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Services
+            </Link>
+            <Link
+              href="/blog"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Blogs
+            </Link>
+            <Link
+              href="/about"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              About Us
+            </Link>
+            <Link
+              href="/careers"
+              className="text-gray-300 hover:text-white hover:border-b-2 hover:border-white transition"
+            >
+              Careers
+            </Link>
           </nav>
           <Link href="/contact">
             <button
@@ -140,19 +165,39 @@ export default function Careers() {
 
       {/* Mobile Nav */}
       <nav className="fixed bottom-0 left-0 right-0 bg-black/80 backdrop-blur-md border-t border-white/20 text-white flex justify-around items-center py-3 md:hidden z-50">
-        <Link href="/" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span>Home</span>
         </Link>
-        <Link href="/services" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/services"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span>Services</span>
         </Link>
-        <Link href="/blogs" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/blog"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span>Blogs</span>
         </Link>
-        <Link href="/contact" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/contact"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span>Contact</span>
         </Link>
-        <Link href="/careers" className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition" onClick={vibrateAndroid}>
+        <Link
+          href="/careers"
+          className="flex flex-col items-center text-xs hover:text-[#6699cc] hover:underline transition"
+          onClick={vibrateAndroid}
+        >
           <span>Careers</span>
         </Link>
       </nav>

--- a/pages/services.js
+++ b/pages/services.js
@@ -1,0 +1,22 @@
+"use client";
+
+import Head from "next/head";
+import UnderDevelopment from "@/components/UnderDevelopment";
+
+export default function Service() {
+  return (
+    <>
+      <Head>
+        <title>Services – Arctic44</title>
+        <meta
+          name="description"
+          content="Our services are currently under development."
+        />
+      </Head>
+      <UnderDevelopment
+        title="Services"
+        description="This page is currently under development."
+      />
+    </>
+  );
+}


### PR DESCRIPTION
This PR cleans up and standardizes navigation and CTA link behavior:

* Use `/#services` when on the home page, `/services` on other pages
* Update “Get Started” button in /#services (service section in home page) to always go to `/services`
* Align header and footer links to `/about`, `/blog`, `/services`
* Created a reusable UnderDevelopment component with global styles and a top navigation bar and add blog and service pages with under development 


